### PR TITLE
(iOS) Fix KeyNotFoundException during CheckIfStayed

### DIFF
--- a/Geofence/Geofence/Geofence.Plugin.iOS/GeofenceImplementation.cs
+++ b/Geofence/Geofence/Geofence.Plugin.iOS/GeofenceImplementation.cs
@@ -314,12 +314,11 @@ namespace Geofence.Plugin
       /// <returns></returns>
       public async Task CheckIfStayed(string regionId)
       {
-         
-          if (CrossGeofence.Current.GeofenceResults.ContainsKey(regionId) && CrossGeofence.Current.Regions.ContainsKey(regionId) && CrossGeofence.Current.Regions[regionId].NotifyOnStay && CrossGeofence.Current.GeofenceResults[regionId].Transition == GeofenceTransition.Entered && CrossGeofence.Current.Regions[regionId].StayedInThresholdDuration.TotalMilliseconds != 0)
+          if (GeofenceRegionExists(regionId) && CrossGeofence.Current.Regions[regionId].NotifyOnStay && CrossGeofence.Current.GeofenceResults[regionId].Transition == GeofenceTransition.Entered && CrossGeofence.Current.Regions[regionId].StayedInThresholdDuration.TotalMilliseconds != 0)
           {
               await Task.Delay((int)CrossGeofence.Current.Regions[regionId].StayedInThresholdDuration.TotalMilliseconds);
 
-              if (CrossGeofence.Current.GeofenceResults[regionId].LastExitTime == null && CrossGeofence.Current.GeofenceResults[regionId].Transition != GeofenceTransition.Stayed)
+              if (GeofenceRegionExists(regionId) && CrossGeofence.Current.GeofenceResults[regionId].LastExitTime == null && CrossGeofence.Current.GeofenceResults[regionId].Transition != GeofenceTransition.Stayed)
               {
                   CrossGeofence.Current.GeofenceResults[regionId].Transition = GeofenceTransition.Stayed;
 
@@ -333,6 +332,17 @@ namespace Geofence.Plugin
               }
           }
       }
+
+      /// <summary>
+      /// Checks if a GeofenceRegion exists in the monitored regions
+      /// </summary>
+      /// <returns><c>true</c>, if it exists, <c>false</c> otherwise.</returns>
+      /// <param name="regionId">Region identifier.</param>
+      bool GeofenceRegionExists(string regionId)
+      {
+          return CrossGeofence.Current.GeofenceResults.ContainsKey (regionId) && CrossGeofence.Current.Regions.ContainsKey (regionId);
+      }
+
       void RegionLeft(object sender, CLRegionEventArgs e)
       {
           if (!GeofenceResults.ContainsKey(e.Region.Identifier)||GeofenceResults[e.Region.Identifier].Transition != GeofenceTransition.Exited)


### PR DESCRIPTION
Hey,

We have noticed this exception occurring in our application that relies on NotifyOnStay but also changes the geofences being monitored fairly often (via `StopMonitoringAllRegions` -> `StartMonitoring` with the new geofence set) every 30minutes or so.

> System.Collections.Generic.KeyNotFoundExceptionThe given key was not present in the dictionary.
> System.ThrowHelper.ThrowKeyNotFoundException()
> System.Collections.Generic.Dictionary<TKey, TValue>.get_Item(TKey key)
> Geofence.Plugin.GeofenceImplementation.<CheckIfStayed>d__30.MoveNext()

This is just a small tweak to ensure that the region still exists in the internal dictionaries before accessing them after the [Task.Delay](https://github.com/domaven/xamarin-plugins/blob/cc4c1c396061ba53ef79d2f55a591911acc4b9fc/Geofence/Geofence/Geofence.Plugin.iOS/GeofenceImplementation.cs#L322) so that the KeyNotFoundException isn't thrown.

Thanks!
